### PR TITLE
Adjust docs for XAMPP default settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Configurações de acesso ao MySQL
 DB_HOST=localhost
 DB_USER=root
-DB_PASSWORD=senha
+DB_PASSWORD=
 DB_NAME=ecommerce

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Backend em Node.js + Express + MySQL para um e-commerce simples.
 
 ## Configuração
 
-1. Crie o arquivo `.env` com as seguintes variáveis:
+1. Crie o arquivo `.env` com as seguintes variáveis (exemplo para XAMPP com usuário `root` sem senha):
 
     ```env
     DB_HOST=localhost
-    DB_USER=seu_usuario
-    DB_PASSWORD=sua_senha
-    DB_NAME=seu_banco
+    DB_USER=root
+    DB_PASSWORD=
+    DB_NAME=ecommerce
     PORT=3000
     ```
 


### PR DESCRIPTION
## Summary
- update `.env.example` to use root with no password
- clarify README instructions for local XAMPP setup

## Testing
- `npm install`